### PR TITLE
Fixes TypeError Cannot read properties of null

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -128,7 +128,9 @@ module.exports = function (app, options) {
     app.streambundle
       .getSelfStream("navigation.position")
       .forEach((position) => {
-        currentCoordinates = [position.longitude, position.latitude];
+        if (position) {
+          currentCoordinates = [position.longitude, position.latitude];
+        }
       });
 
     app.streambundle


### PR DESCRIPTION
Basic fix to remove ugly error from the log

before
```
Mar 30 15:07:38 [signalk-to-nmea0183] GGA: no position, not converting
Mar 30 15:07:38 TypeError: Cannot read properties of null (reading 'longitude') at /home/pi/.signalk/node_modules/vhfinfo/plugin/index.js:131:40 at /usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:3562:24 at /usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:516:29 at processAfters (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:405:21) at Object.inTransaction (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:494:13) at Dispatcher.push (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2408:30) at Dispatcher.handleEvent (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2467:25) at /usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:77:36 at Bus.wrappedSink [as sink] (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2740:28) at Bus.push (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:5153:29) at Bus.push (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:77:36) at StreamBundle.push (/usr/lib/node_modules/signalk-server/dist/streambundle.js:135:42) at /usr/lib/node_modules/signalk-server/dist/streambundle.js:101:34 at Array.forEach (<anonymous>) at /usr/lib/node_modules/signalk-server/dist/streambundle.js:100:39 at Array.forEach (<anonymous>) at StreamBundle.pushDelta (/usr/lib/node_modules/signalk-server/dist/streambundle.js:82:31) at FullSignalK.emit (node:events:531:35) at FullSignalK.addDelta (/usr/lib/node_modules/signalk-server/node_modules/@signalk/signalk-schema/dist/fullsignalk.js:52:8) at DeltaChain.doProcess (/usr/lib/node_modules/signalk-server/dist/deltachain.js:18:18) at /usr/lib/node_modules/signalk-server/dist/deltachain.js:37:22 at Array.<anonymous> (/usr/lib/node_modules/signalk-server/dist/api/notifications/index.js:60:17) at DeltaChain.doProcess (/usr/lib/node_modules/signalk-server/dist/deltachain.js:21:26) at DeltaChain.process (/usr/lib/node_modules/signalk-server/dist/deltachain.js:14:21) at Server.app.handleMessage (/usr/lib/node_modules/signalk-server/dist/index.js:267:38) at Simple.<anonymous> (/usr/lib/node_modules/signalk-server/dist/pipedproviders.js:82:17) at Simple.emit (node:events:531:35) at addChunk (node:internal/streams/readable:561:12)

```

after
```
Mar 30 15:20:59 [signalk-to-nmea0183] GGA: no position, not converting
Mar 30 15:20:59 2026-03-30T14:20:59.355Z vhfinfo createSearchPolygon: coordinates info is missing (navigation.position)
Mar 30 15:20:59 2026-03-30T14:20:59.357Z vhfinfo searchPolygon is null
Mar 30 15:21:00 [signalk-to-nmea0183] GGA: no position, not converting
```
