### PR TITLE
Set up Cloud Agent dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+VHFinfo is a maritime VHF-channel dataset (`data/*.json` GeoJSON) plus two consumers:
+
+- **Map website** (`website/`): a static Leaflet map (`website/map.html`, `website/index.html`). It has no build step and pulls its GeoJSON at runtime from `https://raw.githubusercontent.com/htool/vhfinfo/main/data/...` (needs outbound internet), not from the local `data/` dir.
+- **SignalK plugin** (`plugin/index.js`): the npm package itself (`main` in `package.json`). It runs inside an external SignalK server host and exposes `/plugins/vhfinfo/nearby` + `/plugins/vhfinfo/options`.
+
+### Setup / run notes (non-obvious)
+
+- `npm install` is the only dependency step; there is **no build and no test suite**. The only npm script is `format` (Prettier). Running `npm install` may re-sync `package-lock.json` to `package.json` (version/pins) — that lockfile churn is unrelated to your change; discard it unless intended.
+- **Lint** = Prettier with repo-specific flags: `npx prettier --check --no-semi --single-quote 'plugin/*'`. The committed `plugin/index.js` does **not** currently match this style, so `--check` reports a warning by design. `npm run format` rewrites files in place — only run it if you intend to reformat.
+- **Serve the map website** as static files, e.g. `python3 -m http.server 8080` from inside `website/`, then open `http://localhost:8080/map.html`. VHF polygons only load at **zoom ≥ 6** while the map is centered over a country that has data. Jump straight to a dense area with the `mapPosition` URL param, which is **slash-separated** `lat/lon/zoom` (not comma), e.g. `http://localhost:8080/map.html?mapPosition=51.95/4.05/11` (Rotterdam). Clicking a polygon opens a popup with name/callsign/channel/type.
+- **Run the SignalK plugin end-to-end without a full SignalK server**: `signalk-server` is the external host and is *not* a dependency of this repo (it has heavy native deps), so it is intentionally not in the update script. To exercise the real plugin code with only this repo's deps, load `plugin/index.js` with a mock `app` that implements `app.streambundle.getSelfStream(path).forEach(cb)`, `app.handleMessage`, `app.debug`, `app.error`, and `app.config.configPath`. The plugin reads data from `path.join(app.config.configPath, "node_modules/vhfinfo/data/")`, so point `configPath` at a dir containing `node_modules/vhfinfo` → this repo (a symlink works). Emit a `navigation.position` (`{longitude, latitude}`) value, then wait ~11s: the plugin only loads features into memory **10s after start** and recomputes nearby features every 5s. Read results by calling the captured `/nearby` router handler. Providing no heading makes the search omnidirectional (bbox); with a heading it uses a directional beam (`options.angle` / `options.distance`). When running inside a real SignalK server, install this package into the server's config dir (`<configdir>/node_modules/vhfinfo`) and feed it a position via a data connection or a stream delta.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for VHFinfo, and documents non-obvious startup/run caveats for future Cloud Agents in a new `AGENTS.md`.

VHFinfo has two runnable products, both exercised end-to-end:
- **Map website** (`website/`): static Leaflet map, no build; loads GeoJSON from GitHub raw at runtime.
- **SignalK plugin** (`plugin/index.js`): the npm package `main`, meant to run inside a SignalK host, exposes `/plugins/vhfinfo/nearby`.

## What was done

- Installed dependencies with `npm install` (the only dependency step — there is no build and no test suite).
- Ran the lint tooling: `npx prettier --check --no-semi --single-quote 'plugin/*'` (works; the committed file intentionally doesn't match the style).
- Served the map website (`python3 -m http.server 8080` in `website/`) and confirmed VHF area polygons render over Rotterdam and clicking a feature shows channel info popups.
- Ran the SignalK plugin's real code via a SignalK-compatible harness (using only repo deps + data): fed a GPS position and got nearby VHF areas back from the `/nearby` API, sorted by distance.
- Added `AGENTS.md` `## Cursor Cloud specific instructions` capturing non-obvious gotchas (slash-separated `mapPosition`, zoom≥6 feature loading, GitHub-raw data source, plugin data-dir layout + 10s feature-load delay, prettier flags).

## Verification

### Map website
[vhfinfo_map_demo.mp4](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvhfinfo_map_demo.mp4)
[VHF polygons over Rotterdam](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvhfinfo_map_polygons.webp)
[VHF channel info popup](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvhfinfo_map_popup.webp)

### SignalK plugin `/nearby` API output
```
=== GET /plugins/vhfinfo/nearby ===
Nearby VHF features found: 10
  [0] VTS        ch 3    255m  Hoek van Holland (Sector Maasmond)
  [1] VTS        ch 66   931m  Traffic Centre Hoek van Holland (Sector Europoort)
  [2] TERRITORIAL ch 16   1516m  Netherlands (-)
  [3] VTS        ch 65   4114m  Hoek van Holland (Sector Rozenburg)
  ...
SUCCESS: plugin returned nearby VHF info via /nearby API
```

## Update script

`npm install` (minimal; `signalk-server` is an external host with heavy native deps and is intentionally not included).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

