### PR TITLE
Fix edit-mode feature highlight lagging one click behind

### DIFF
--- a/website/map.html
+++ b/website/map.html
@@ -1431,6 +1431,38 @@
         };
       }
 
+      function vhfSelectedStyle() {
+        return {
+          fillOpacity: 0.45,
+          weight: 3,
+          opacity: 0.9,
+          dashArray: "",
+        };
+      }
+
+      function applySelectedStyle(layer) {
+        if (!layer || !layer.setStyle) {
+          return;
+        }
+        layer.setStyle(vhfSelectedStyle());
+        if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
+          layer.bringToFront();
+        }
+      }
+
+      function restoreLayerStyle(layer) {
+        if (!layer) {
+          return;
+        }
+        var resetLayer = layer._vhfResetLayer;
+        if (resetLayer && resetLayer.resetStyle) {
+          resetLayer.resetStyle(layer);
+        } else if (layer.setStyle) {
+          layer.setStyle(layer._vhfPrevStyle || vhfFeatureStyle());
+        }
+        layer._vhfPrevStyle = null;
+      }
+
       function typeLayerFor(type) {
         switch (type) {
           case "vts":
@@ -1461,24 +1493,30 @@
         }
         layer._vhfCountry = country;
         layer._vhfSource = vhfCountrySource[country] || "github";
+        layer._vhfResetLayer = resetLayer;
         layer.on({
           mouseover: function (e) {
-            e.target.setStyle({
+            var l = e.target;
+            if (l === currentEditLayer) {
+              return;
+            }
+            l.setStyle({
               fillOpacity: 0.4,
               dashArray: "",
               weight: 2,
               opacity: 0.2,
             });
             if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
-              e.target.bringToFront();
+              l.bringToFront();
             }
           },
           mouseout: function (e) {
-            if (resetLayer && resetLayer.resetStyle) {
-              resetLayer.resetStyle(e.target);
-            } else {
-              e.target.setStyle(vhfFeatureStyle());
+            var l = e.target;
+            if (l === currentEditLayer) {
+              applySelectedStyle(l);
+              return;
             }
+            restoreLayerStyle(l);
           },
           click: function (e) {
             if (editMode) {
@@ -2237,9 +2275,8 @@
       }
 
       function closeEditor() {
-        if (currentEditLayer && currentEditLayer._vhfPrevStyle) {
-          currentEditLayer.setStyle(currentEditLayer._vhfPrevStyle);
-          currentEditLayer._vhfPrevStyle = null;
+        if (currentEditLayer) {
+          restoreLayerStyle(currentEditLayer);
         }
         currentEditLayer = null;
         document.body.classList.remove("editor-open");
@@ -2288,28 +2325,15 @@
           return;
         }
         m.closePopup();
-        if (
-          currentEditLayer &&
-          currentEditLayer !== layer &&
-          currentEditLayer._vhfPrevStyle
-        ) {
-          currentEditLayer.setStyle(currentEditLayer._vhfPrevStyle);
+        if (currentEditLayer && currentEditLayer !== layer) {
+          restoreLayerStyle(currentEditLayer);
         }
         currentEditLayer = layer;
         var p = ensureFeatureDefaults(layer, false);
         if (layer.setStyle) {
-          layer._vhfPrevStyle = {
-            fillOpacity: layer.options && layer.options.fillOpacity,
-            weight: layer.options && layer.options.weight,
-            opacity: layer.options && layer.options.opacity,
-            dashArray: layer.options && layer.options.dashArray,
-          };
-          layer.setStyle({
-            fillOpacity: 0.45,
-            weight: 3,
-            opacity: 0.9,
-            dashArray: "",
-          });
+          // Capture default style, not hover, so selection does not lag one click behind.
+          layer._vhfPrevStyle = vhfFeatureStyle();
+          applySelectedStyle(layer);
         }
         document.getElementById("editor-title").textContent = p.name
           ? p.name


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Clicking several VHF areas in edit mode left the selection highlight one click behind: the previously clicked polygon stayed visually selected.

**Cause**
- `mouseover` applied hover style.
- `openEditor` saved that hover style as `_vhfPrevStyle`, then applied the selected style.
- `mouseout` called `resetStyle` even on the selected layer, so the highlight disappeared immediately.
- The next click restored the previous layer to the captured hover style, which looked selected.

**Fix**
- Save the default `vhfFeatureStyle()` instead of the current hover options.
- Skip hover styling while a layer is selected, and re-apply the selected style on `mouseout`.
- Restore the previous layer with GeoJSON `resetStyle` (or the default style) when switching or closing the editor.

**Tested**
- Same mouseover → click → mouseout sequence against `main` still lags (selected fill drops to `0.15`, previous layer stays at hover `0.4`).
- After this change, five sequential NLD areas keep selected fill `0.45` and the previous area returns to default `0.15`.
- Rotterdam bridges: editor title and highlight stay in sync for Erasmusbrug → Koninginnebrug → De Hef.

[Erasmusbrug selected](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhighlight_matches_erasmusbrug.png)
[Koninginnebrug selected](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhighlight_matches_koninginnebrug.png)
[De Hef selected](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhighlight_matches_de_hef.png)
[edit_highlight_three_bridges.mp4](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_highlight_three_bridges.mp4)

No auth or publish changes. After merge, re-upload `website/map.html` to vhfinfo.org.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

