### PR TITLE
Keep the info popup closed when editing a VHF area

### DIFF
--- a/website/map.html
+++ b/website/map.html
@@ -1450,6 +1450,36 @@
         }
       }
 
+      function dismissFeaturePopup(layer) {
+        if (layer && layer.closePopup) {
+          layer.closePopup();
+        }
+        if (layer && layer.unbindPopup) {
+          layer.unbindPopup();
+        }
+        m.closePopup();
+      }
+
+      function unbindAllFeaturePopups() {
+        function strip(group) {
+          if (!group || !group.eachLayer) {
+            return;
+          }
+          group.eachLayer(function (layer) {
+            dismissFeaturePopup(layer);
+          });
+        }
+        strip(vtsLayer);
+        strip(radarLayer);
+        strip(lockLayer);
+        strip(bridgeLayer);
+        strip(marinaLayer);
+        strip(areaLayer);
+        strip(Nm12);
+        strip(drawnItems);
+        m.closePopup();
+      }
+
       function restoreLayerStyle(layer) {
         if (!layer) {
           return;
@@ -1520,7 +1550,11 @@
           },
           click: function (e) {
             if (editMode) {
-              L.DomEvent.stopPropagation(e);
+              L.DomEvent.stop(e);
+              if (e.originalEvent) {
+                L.DomEvent.stop(e.originalEvent);
+              }
+              dismissFeaturePopup(e.target);
               openEditor(e.target);
             } else {
               showInfo(e.target.feature, e.target, country);
@@ -1703,6 +1737,7 @@
             if (forEdit || (editMode && country === code)) {
               addCountryLayersToDrawnItems(code);
               setEditCountBanner(code, features.length, true);
+              unbindAllFeaturePopups();
             }
           })
           .catch(function (err) {
@@ -1889,7 +1924,9 @@
           country +
           '" style="text-decoration: none;">Change this info</a></td></tr>';
         html = html + "</table>";
-
+        if (editMode) {
+          return;
+        }
         layer.bindPopup(html).openPopup();
         layer.addTo(m);
       }
@@ -1999,7 +2036,11 @@
         ensureFeatureDefaults(layer, true);
         layer.on("click", function (evt) {
           if (editMode) {
-            L.DomEvent.stopPropagation(evt);
+            L.DomEvent.stop(evt);
+            if (evt.originalEvent) {
+              L.DomEvent.stop(evt.originalEvent);
+            }
+            dismissFeaturePopup(layer);
             openEditor(layer);
           }
         });
@@ -2121,6 +2162,7 @@
         $(".leaflet-container").css("cursor", "crosshair");
         setOrientation();
         setTimeout(removeUnwanted, 500);
+        unbindAllFeaturePopups();
         closeEditor();
         if (typeof updateAuthUi === "function") {
           updateAuthUi();
@@ -2325,6 +2367,7 @@
           return;
         }
         m.closePopup();
+        dismissFeaturePopup(layer);
         if (currentEditLayer && currentEditLayer !== layer) {
           restoreLayerStyle(currentEditLayer);
         }
@@ -2616,6 +2659,17 @@
           m.removeLayer(areaLayer);
         }
       }
+
+      m.on("popupopen", function () {
+        if (!editMode) {
+          return;
+        }
+        setTimeout(function () {
+          if (editMode) {
+            m.closePopup();
+          }
+        }, 0);
+      });
 
       m.on("zoomend", function () {
         checkIfLoaded();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In edit mode, clicking a VHF area (reported on Den Helder VTS) opened the right-hand editor and also the view-mode info popup.

**Cause**
A click in view mode calls `bindPopup()` on that polygon. Leaflet then opens that popup on the next click. Edit mode already opened the side panel, then closed the popup, then Leaflet’s popup handler opened it again.

**Fix**
- Unbind feature popups when entering edit mode and after loading areas for edit.
- On an edit-mode click, stop the event and dismiss any popup before opening the editor.
- Ignore `showInfo` while editing, and close any popup that still opens.

**Tested**
- View-mode click on Den Helder binds the `[VTS] Den Helder` popup.
- On `main`, entering edit and clicking again left that popup open together with the editor.
- After this change, the same sequence opens the Den Helder editor with zero Leaflet popups.

[Den Helder editor without info popup](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_den_helder_no_popup.png)
[edit_den_helder_no_info_popup.mp4](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_den_helder_no_info_popup.mp4)

After merge, re-upload `website/map.html` to vhfinfo.org.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

