### PR TITLE
Leave edit mode after publish instead of reloading

### DIFF
--- a/website/map.html
+++ b/website/map.html
@@ -690,6 +690,7 @@
         </p>
         <p id="publish-as"></p>
         <ul id="publish-list"></ul>
+        <div id="publish-error" class="auth-message auth-error"></div>
         <p>
           <label for="publish-note"><b>Short note</b></label
           ><br />
@@ -2042,6 +2043,8 @@
             }
             dismissFeaturePopup(layer);
             openEditor(layer);
+          } else if (layer.feature) {
+            showInfo(layer.feature, layer, layer._vhfCountry || country);
           }
         });
         openEditor(layer);
@@ -2523,11 +2526,75 @@
           list.appendChild(li);
         });
         updateAuthUi();
+        showPublishError("");
         document.getElementById("publish-modal").style.display = "block";
       }
 
       function closePublishModal() {
         document.getElementById("publish-modal").style.display = "none";
+        showPublishError("");
+      }
+
+      function showPublishError(msg) {
+        var el = document.getElementById("publish-error");
+        if (!el) {
+          return;
+        }
+        el.textContent = msg || "";
+        el.style.display = msg ? "block" : "none";
+      }
+
+      function publishErrorText(err) {
+        if (!err) {
+          return "Could not publish.";
+        }
+        if (typeof err === "string") {
+          return err;
+        }
+        if (err.message) {
+          return String(err.message);
+        }
+        if (err.error_description) {
+          return String(err.error_description);
+        }
+        try {
+          return JSON.stringify(err);
+        } catch (e) {
+          return "Could not publish.";
+        }
+      }
+
+      function setPublishBusy(busy) {
+        var btn = document.getElementById("publish-confirm");
+        if (!btn) {
+          return;
+        }
+        btn.disabled = !!busy;
+        btn.textContent = busy ? "Publishing…" : "Publish";
+      }
+
+      function attachPublishedLayer(layer) {
+        if (!layer || !layer.feature) {
+          return;
+        }
+        var p = layer.feature.properties || {};
+        var specific = typeLayerFor(p.type);
+        if (specific && !specific.hasLayer(layer)) {
+          specific.addLayer(layer);
+        }
+      }
+
+      function finishSuccessfulPublish() {
+        Object.keys(changedIds).forEach(function (uuid) {
+          var info = changedIds[uuid];
+          if (!info || info.action === "Delete") {
+            return;
+          }
+          attachPublishedLayer(m._layers[info.leaflet_id]);
+        });
+        changedIds = {};
+        closePublishModal();
+        exitEditMode();
       }
 
       function confirmPublish() {
@@ -2536,11 +2603,11 @@
           return;
         }
         var email = getSignedInEmail();
-        var note = document.getElementById("publish-note").value.trim();
         if (!email || email.indexOf("@") < 0) {
-          alert("Please sign in again, then publish.");
+          showPublishError("Please sign in again, then publish.");
           return;
         }
+        showPublishError("");
         Object.keys(changedIds).forEach(function (uuid) {
           var info = changedIds[uuid];
           if (info.action != "Delete") {
@@ -2559,21 +2626,34 @@
           !window.vhfFeaturesDb ||
           typeof window.vhfFeaturesDb.publishFeaturesToDb !== "function"
         ) {
-          alert("Could not publish: the database helper is missing.");
+          showPublishError("Could not publish: the database helper is missing.");
           return;
         }
+        setPublishBusy(true);
         window.vhfFeaturesDb
           .publishFeaturesToDb(publishCountry, publishPayload)
           .then(function (result) {
-            if (result && result.error) {
-              alert("Could not publish: " + result.error);
+            if (result && result.reason === "not-signed-in") {
+              showPublishError("Please sign in again, then publish.");
               return;
             }
-            closePublishModal();
-            location.reload();
+            if (result && result.error) {
+              showPublishError("Could not publish: " + publishErrorText(result.error));
+              return;
+            }
+            if (result && result.empty && result.skipped && result.skipped.length) {
+              showPublishError(
+                "Could not publish: some areas were missing their shape.",
+              );
+              return;
+            }
+            finishSuccessfulPublish();
           })
           .catch(function (err) {
-            alert("Could not publish: " + ((err && err.message) || String(err)));
+            showPublishError("Could not publish: " + publishErrorText(err));
+          })
+          .then(function () {
+            setPublishBusy(false);
           });
       }
 

--- a/website/map.html
+++ b/website/map.html
@@ -2554,6 +2554,12 @@
         if (err.message) {
           return String(err.message);
         }
+        if (err.details) {
+          return String(err.details);
+        }
+        if (err.hint) {
+          return String(err.hint);
+        }
         if (err.error_description) {
           return String(err.error_description);
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After Publish, the map reloaded to `map.html` and could show `[object Object]` from leftover git-commit result handling (`alert(result)`). A failed publish must not throw away in-progress edits.

**After a successful publish**
- Close the publish dialog
- Leave edit mode in place (no `location.reload()`, URL and map view stay put)
- Keep published polygons on the map

**If publish fails**
- Stay in edit mode
- Keep unpublished changes
- Show a readable error in the publish dialog instead of `alert([object Object])`

[Failed publish keeps the editor and shows a readable error](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublish_failure_keeps_editor.png)
[Successful publish leaves edit mode without reloading](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublish_success_left_edit_mode.png)
[publish_fail_then_leave_edit_mode.mp4](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublish_fail_then_leave_edit_mode.mp4)

After merge, re-upload `website/map.html` to vhfinfo.org.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

