### PR TITLE
Keep areas visible after Done and drop the extra popup link

### DIFF
--- a/website/map.html
+++ b/website/map.html
@@ -1946,13 +1946,6 @@
               json.phone +
               "</a></td></tr>";
           }
-          if (typeof json.url != "undefined") {
-            h =
-              h +
-              '<tr><td>Info</td><td><a href="' +
-              json.url +
-              '" target="_blank">link</a></td></tr>';
-          }
           if (h.length > 0) {
             h = '<tr><td colspan="2"><b>' + title + "</td></b></tr>" + h;
           }
@@ -2273,6 +2266,20 @@
         exitEditMode();
       }
 
+      function returnLayerToTypeGroup(layer) {
+        if (!layer) {
+          return;
+        }
+        var p = layer.feature && layer.feature.properties;
+        var specific = p && typeLayerFor(p.type);
+        if (specific) {
+          specific.addLayer(layer);
+        } else if (m && !m.hasLayer(layer)) {
+          m.addLayer(layer);
+        }
+        restoreLayerStyle(layer);
+      }
+
       function exitEditMode() {
         closeEditor();
         editMode = false;
@@ -2286,7 +2293,13 @@
           layers.push(layer);
         });
         layers.forEach(function (layer) {
+          var p = layer.feature && layer.feature.properties;
+          var discardNew =
+            p && changedIds[p.id] && changedIds[p.id].action === "Add";
           drawnItems.removeLayer(layer);
+          if (!discardNew) {
+            returnLayerToTypeGroup(layer);
+          }
         });
         m.removeEventListener("mousemove", editMouseMove);
         $(".leaflet-container").css("cursor", "");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two view-mode fixes after leaving the editor.

**Duplicate popup link**
The info popup showed `Info / link` twice: once for the area website and again for the pleasure-craft URL. The extra row is removed; the main website link stays.

**Done hid the edited country**
Leaving edit mode took polygons off the map because Leaflet removes a layer from the map when it leaves the draw group. Existing areas are put back on their VTS/lock/bridge layers. Unpublished new drawings are still discarded.

On `main`, Den Helder’s popup had two `link` rows and after Done all 39 NLD VTS polygons were off the map. After this change: one `link`, and all 39 stay visible.

[Den Helder popup with a single Info link](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpopup_one_info_link.png)
[Netherlands VHF areas still visible after Done](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_done_country_still_visible.png)

After merge, re-upload `website/map.html` to vhfinfo.org.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

