### PR TITLE
Open the side editor from Edit this info

### DIFF
--- a/website/map.html
+++ b/website/map.html
@@ -1859,6 +1859,35 @@
         );
       }
 
+      function escapeHtml(text) {
+        return String(text)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;");
+      }
+
+      function shortUrlLabel(url) {
+        var raw = String(url || "").trim();
+        if (!raw) {
+          return "";
+        }
+        var display = raw.replace(/^https?:\/\//i, "").replace(/^www\./i, "");
+        try {
+          var parsed = new URL(raw);
+          var host = (parsed.hostname || "").replace(/^www\./i, "");
+          var path = parsed.pathname || "";
+          if (path === "/") {
+            path = "";
+          }
+          display = host + path;
+        } catch (err) {}
+        if (display.length > 36) {
+          display = display.slice(0, 34) + "\u2026";
+        }
+        return display;
+      }
+
       function showInfo(f, layer, country) {
         // console.log(f)
         // console.log(layer)
@@ -1887,12 +1916,16 @@
           p.vhfdata.generic.mode +
           ")</td></tr>";
 
-        if (typeof p.url != "undefined") {
+        if (typeof p.url != "undefined" && p.url) {
           html =
             html +
             '<tr><td>Info</td><td><a href="' +
-            p.url +
-            '" target="_blank">link</a></td></tr>';
+            escapeHtml(p.url) +
+            '" title="' +
+            escapeHtml(p.url) +
+            '" target="_blank" rel="noopener noreferrer">' +
+            escapeHtml(shortUrlLabel(p.url)) +
+            "</a></td></tr>";
         }
         if (typeof p.phone != "undefined") {
           html =

--- a/website/map.html
+++ b/website/map.html
@@ -1946,13 +1946,6 @@
               json.phone +
               "</a></td></tr>";
           }
-          if (typeof json.url != "undefined") {
-            h =
-              h +
-              '<tr><td>Info</td><td><a href="' +
-              json.url +
-              '" target="_blank">link</a></td></tr>';
-          }
           if (h.length > 0) {
             h = '<tr><td colspan="2"><b>' + title + "</td></b></tr>" + h;
           }

--- a/website/map.html
+++ b/website/map.html
@@ -121,6 +121,9 @@
       .leaflet-popup-pane {
         width: 20%;
       }
+      body.editing .leaflet-popup {
+        display: none !important;
+      }
       .edit {
         font-size: 1.55rem;
         z-index: 999;
@@ -757,6 +760,7 @@
       var vhfCountrySource = {};
       var vhfCountryCounts = {};
       var vhfLoadSeq = {};
+      var pendingEditFeatureId = null;
       var GITHUB_DATA =
         "https://raw.githubusercontent.com/htool/vhfinfo/main/data/";
       var activeCountry = "";
@@ -1467,6 +1471,11 @@
           }
           group.eachLayer(function (layer) {
             dismissFeaturePopup(layer);
+            if (layer.eachLayer) {
+              layer.eachLayer(function (child) {
+                dismissFeaturePopup(child);
+              });
+            }
           });
         }
         strip(vtsLayer);
@@ -1477,7 +1486,78 @@
         strip(areaLayer);
         strip(Nm12);
         strip(drawnItems);
+        if (m && m.eachLayer) {
+          m.eachLayer(function (layer) {
+            dismissFeaturePopup(layer);
+          });
+        }
         m.closePopup();
+      }
+
+      function featureIdOfLayer(layer) {
+        if (!layer || !layer.feature) {
+          return "";
+        }
+        var props = layer.feature.properties || {};
+        return String(props.id || layer.feature.id || "");
+      }
+
+      function findLayerByFeatureId(featureId) {
+        if (!featureId) {
+          return null;
+        }
+        var want = String(featureId);
+        var found = null;
+        function visit(layer) {
+          if (found || !layer) {
+            return;
+          }
+          if (featureIdOfLayer(layer) === want) {
+            found = layer;
+            return;
+          }
+          if (layer.eachLayer) {
+            layer.eachLayer(visit);
+          }
+        }
+        visit(drawnItems);
+        visit(vtsLayer);
+        visit(radarLayer);
+        visit(lockLayer);
+        visit(bridgeLayer);
+        visit(marinaLayer);
+        visit(areaLayer);
+        visit(Nm12);
+        if (!found && m && m.eachLayer) {
+          m.eachLayer(visit);
+        }
+        return found;
+      }
+
+      function openPendingEditFeature() {
+        if (!pendingEditFeatureId || !editMode) {
+          return;
+        }
+        var id = pendingEditFeatureId;
+        var attempts = 0;
+        function tryOpen() {
+          if (!editMode || pendingEditFeatureId !== id) {
+            return;
+          }
+          var layer = findLayerByFeatureId(id);
+          if (layer) {
+            pendingEditFeatureId = null;
+            dismissFeaturePopup(layer);
+            m.closePopup();
+            openEditor(layer);
+            return;
+          }
+          attempts += 1;
+          if (attempts < 40) {
+            setTimeout(tryOpen, 100);
+          }
+        }
+        tryOpen();
       }
 
       function restoreLayerStyle(layer) {
@@ -1555,10 +1635,11 @@
                 L.DomEvent.stop(e.originalEvent);
               }
               dismissFeaturePopup(e.target);
+              m.closePopup();
               openEditor(e.target);
-            } else {
-              showInfo(e.target.feature, e.target, country);
+              return;
             }
+            showInfo(e.target.feature, e.target, country);
           },
           contextmenu: function (e) {
             if (resetLayer && resetLayer.bringToBack) {
@@ -1677,6 +1758,8 @@
           if (forEdit) {
             addCountryLayersToDrawnItems(code);
             setEditCountBanner(code, vhfCountryCounts[code] || 0, true);
+            unbindAllFeaturePopups();
+            openPendingEditFeature();
           }
           return;
         }
@@ -1738,6 +1821,7 @@
               addCountryLayersToDrawnItems(code);
               setEditCountBanner(code, features.length, true);
               unbindAllFeaturePopups();
+              openPendingEditFeature();
             }
           })
           .catch(function (err) {
@@ -1889,8 +1973,10 @@
       }
 
       function showInfo(f, layer, country) {
-        // console.log(f)
-        // console.log(layer)
+        if (editMode) {
+          dismissFeaturePopup(layer);
+          return;
+        }
 
         let p = f.properties;
 
@@ -1954,14 +2040,20 @@
         html =
           html +
           '<tr><td></td><td style="text-align: right;"><a href="#" class="popup-edit-link" data-country="' +
-          country +
-          '" style="text-decoration: none;">Change this info</a></td></tr>';
+          escapeHtml(country || "") +
+          '" data-id="' +
+          escapeHtml((p && p.id) || "") +
+          '" style="text-decoration: none;">Edit this info</a></td></tr>';
         html = html + "</table>";
-        if (editMode) {
-          return;
+        if (layer.unbindPopup) {
+          layer.unbindPopup();
         }
         layer.bindPopup(html).openPopup();
-        layer.addTo(m);
+        layer.once("popupclose", function () {
+          if (layer.unbindPopup) {
+            layer.unbindPopup();
+          }
+        });
       }
 
       function addHTML(title, json) {
@@ -2132,6 +2224,7 @@
           return;
         }
         if (editMode && country === code) {
+          openPendingEditFeature();
           return;
         }
         if (editMode && Object.keys(changedIds).length > 0) {
@@ -2158,6 +2251,7 @@
         activeCountry = code;
         editMode = true;
         document.body.classList.add("editing");
+        closeEditor();
         if (splitviewMode) {
           var splitBtn = document.getElementsByClassName("splitview")[0];
           if (splitBtn) {
@@ -2189,10 +2283,10 @@
         setOrientation();
         setTimeout(removeUnwanted, 500);
         unbindAllFeaturePopups();
-        closeEditor();
         if (typeof updateAuthUi === "function") {
           updateAuthUi();
         }
+        openPendingEditFeature();
       }
 
       function editMouseMove(event) {
@@ -2300,6 +2394,7 @@
       }
 
       function exitEditMode() {
+        pendingEditFeatureId = null;
         closeEditor();
         editMode = false;
         document.body.classList.remove("editing");
@@ -2686,15 +2781,13 @@
         }
       }
 
-      m.on("popupopen", function () {
+      m.on("popupopen", function (e) {
         if (!editMode) {
           return;
         }
-        setTimeout(function () {
-          if (editMode) {
-            m.closePopup();
-          }
-        }, 0);
+        var src = e.popup && e.popup._source;
+        dismissFeaturePopup(src);
+        m.closePopup();
       });
 
       m.on("zoomend", function () {
@@ -3146,10 +3239,13 @@
           return;
         }
         e.preventDefault();
+        e.stopPropagation();
+        pendingEditFeatureId = a.getAttribute("data-id") || null;
+        var countryCode = a.getAttribute("data-country");
         m.closePopup();
         requireSignIn(function () {
-          requestEnterEditMode(a.getAttribute("data-country"));
-        }, a.getAttribute("data-country"));
+          requestEnterEditMode(countryCode);
+        }, countryCode);
       });
       L.DomEvent.disableClickPropagation(
         document.getElementById("editor-panel"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The view popup now says **Edit this info** and opens that area in the side editor after sign-in.

Leaflet popups stay closed while editing. Clicking an area uses the side panel only.

Also included from earlier on this branch:
- One website row in the popup (no extra pleasure-craft Info/link)
- Shortened host/path as the clickable text, full URL as the tooltip

[View popup with Edit this info](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpopup_edit_this_info.png)
[Side editor opened for Den Helder](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feditor_opened_from_popup.png)
[edit_this_info_opens_side_editor.mp4](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_this_info_opens_side_editor.mp4)

After merge, re-upload `website/map.html` to vhfinfo.org.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

