### PR TITLE
Stack smaller VHF areas on top of larger ones

### DIFF
--- a/website/HELP.md
+++ b/website/HELP.md
@@ -4,7 +4,7 @@
 
 ### Layers
 You can enable/disable different layer types using the ![26px](documentation/pictures/layers.png) button.
-You can bring an overlapping layer to back by pressing the right mouse button on the underlaying shape.
+Smaller areas are drawn on top of larger ones. Right-click an area to send **that** area behind the others so you can select what is underneath.
 
 ### Splitview mode
 You can disable/enable splitview mode (including map coordinates) using the ![26px](public/splitview.png) button.

--- a/website/map.html
+++ b/website/map.html
@@ -1621,6 +1621,98 @@
         }
       }
 
+      function vhfPathLayerGroups() {
+        return [
+          vtsLayer,
+          radarLayer,
+          lockLayer,
+          bridgeLayer,
+          marinaLayer,
+          areaLayer,
+          Nm12,
+          drawnItems,
+        ];
+      }
+
+      function featureAreaM2(layer) {
+        if (!layer) {
+          return 0;
+        }
+        if (typeof L.Circle !== "undefined" && layer instanceof L.Circle) {
+          var radius = layer.getRadius();
+          return Math.PI * radius * radius;
+        }
+        try {
+          var geo =
+            layer.feature || (layer.toGeoJSON && layer.toGeoJSON());
+          if (!geo) {
+            return 0;
+          }
+          if (geo.type === "FeatureCollection") {
+            return 0;
+          }
+          if (geo.type !== "Feature") {
+            geo = {
+              type: "Feature",
+              properties: {},
+              geometry: geo.geometry || geo,
+            };
+          }
+          if (!geo.geometry || geo.geometry.type === "Point") {
+            return 0;
+          }
+          return turf.area(geo);
+        } catch (err) {
+          return 0;
+        }
+      }
+
+      function collectVhfPathLayers() {
+        var seen = {};
+        var layers = [];
+        function add(layer) {
+          if (!layer || seen[layer._leaflet_id]) {
+            return;
+          }
+          if (layer.eachLayer && !layer.feature) {
+            layer.eachLayer(add);
+            return;
+          }
+          if (!layer.bringToFront) {
+            return;
+          }
+          seen[layer._leaflet_id] = true;
+          layers.push(layer);
+        }
+        vhfPathLayerGroups().forEach(function (group) {
+          if (group && group.eachLayer) {
+            group.eachLayer(add);
+          }
+        });
+        return layers;
+      }
+
+      function orderVhfLayersByArea() {
+        var layers = collectVhfPathLayers();
+        layers.sort(function (a, b) {
+          return featureAreaM2(b) - featureAreaM2(a);
+        });
+        layers.forEach(function (layer) {
+          if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
+            layer.bringToFront();
+          }
+        });
+        if (
+          currentEditLayer &&
+          currentEditLayer.bringToFront &&
+          !L.Browser.ie &&
+          !L.Browser.opera &&
+          !L.Browser.edge
+        ) {
+          currentEditLayer.bringToFront();
+        }
+      }
+
       function onEachVhfFeature(feature, layer, country, resetLayer) {
         if (!feature.properties) {
           feature.properties = {};
@@ -1643,9 +1735,6 @@
               weight: 2,
               opacity: 0.2,
             });
-            if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
-              l.bringToFront();
-            }
           },
           mouseout: function (e) {
             var l = e.target;
@@ -1669,8 +1758,13 @@
             showInfo(e.target.feature, e.target, country);
           },
           contextmenu: function (e) {
-            if (resetLayer && resetLayer.bringToBack) {
-              resetLayer.bringToBack();
+            L.DomEvent.stop(e);
+            if (e.originalEvent) {
+              L.DomEvent.stop(e.originalEvent);
+            }
+            var l = e.target;
+            if (l && l.bringToBack) {
+              l.bringToBack();
             }
           },
         });
@@ -1696,6 +1790,9 @@
               onEachVhfFeature(feature, layer, country, l);
             },
           });
+          l.on("data:loaded", function () {
+            orderVhfLayersByArea();
+          });
         } catch (e) {
           console.log("Loading did not work");
         }
@@ -1712,6 +1809,7 @@
             onEachVhfFeature(feature, layer, country, l);
           },
         });
+        orderVhfLayersByArea();
         return l;
       }
 
@@ -2119,6 +2217,7 @@
               m.removeLayer(l);
             }
             updateNearby();
+            orderVhfLayersByArea();
             break;
           case "remove":
             if (m.hasLayer(l)) {
@@ -2130,6 +2229,7 @@
               m.removeLayer(l);
             }
             updateNearby();
+            orderVhfLayersByArea();
             break;
         }
       }
@@ -2190,6 +2290,7 @@
           }
         });
         openEditor(layer);
+        orderVhfLayersByArea();
       });
 
       m.on("draw:edited", function (e) {
@@ -2210,6 +2311,7 @@
           }
         });
         updatePublishButton();
+        orderVhfLayersByArea();
       });
 
       function friendlyCountry(code) {
@@ -2523,6 +2625,7 @@
         document.body.classList.remove("editor-open");
         showEditorError("");
         m.invalidateSize(true);
+        orderVhfLayersByArea();
       }
 
       function ensureFeatureDefaults(layer, isNew) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Smaller VHF areas (locks, bridges, nested sectors) were often buried under a larger polygon, so a click hit the big sector instead of the feature you could see.

This change:

1. After load, draw, vertex edit, layer toggle, and closing the editor, sorts all VHF paths by area and brings the largest to the front first so the smallest stay on top (VTS, radar, lock, bridge, marina, area, 12 NM).
2. Removes hover `bringToFront`, which was stealing z-order. Fill-opacity hover stays. The layer in the editor still comes to the front; closing the editor restores area order.
3. Right-click sends **that** area behind, not the whole country GeoJSON group. Help text matches this.

Verified at Schellingwoude (`?mapPosition=52.378/4.966/16`):

- Click on the overlap opens **Schellingwoude brug** (VHF 18), not the large sector.
- Hovering the sector does not steal z-order.
- Right-click on the bridge, then click again, opens **Sector Schellingwoude** (VHF 60).
- Closing the editor restores smaller-on-top.
- **Oranjesluizen** (lock) stays clickable on top of the VTS sector.

[Click hits Schellingwoude brug on top of the sector](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fschelling_click_small_on_top.png)
[After right-click, click hits Sector Schellingwoude](https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fschelling_click_after_right_click.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d464b5-d62a-4a69-80fe-e9d9dcefe178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

